### PR TITLE
Fix appCommon.go isValidName()

### DIFF
--- a/app/appCommon.go
+++ b/app/appCommon.go
@@ -71,7 +71,7 @@ func isValidBase64(s string) bool {
 func isValidName(s string) bool {
 
 	for _, r := range s {
-		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || (r == '-') || (r == '_') || (r == ' ')) {
+		if !((r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || (r == '-') || (r == '_') || (r == ' ') || (r == '.') || (r == ':')) {
 			return false
 		}
 	}


### PR DESCRIPTION
Fix #2  isValidName() to allow dots `.` and colons `:` so that the `appsett.env: PANGPLIMITER_GP_GATEWAY` allows hostnames such as `vpn-region1.example.com` without erroring and to be consistent with the error message:

`ERROR: appSett.go:117 GPGateway object ('vpn-region1.example.com') should only contains alphanumeric chars with dot & colon!`